### PR TITLE
Add AWS Cost Saver plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@
 | 98 | [osgrep](https://github.com/Ryandonofrio3/osgrep) | Open Source Semantic Search for your AI Agent | 1029 | 5 | 1 |
 | 99 | [skills](https://github.com/expo/skills) | A collection of AI agent skills for working with Expo projects and Expo Application Services | 1022 | 9 | 3 |
 | 100 | [terraform-skill](https://github.com/antonbabenko/terraform-skill) | The Claude Agent Skill for Terraform and OpenTofu - testing, modules, CI/CD, and production patterns | 1019 | 13 | 1 |
+| 101 | [claude-aws-cost-saver](https://github.com/prajapatimehul/claude-aws-cost-saver) | Claude Code plugin that finds AWS cost savings. 173 automated checks across EC2, RDS, S3, Lambda, and 30+ services. Integrates AWS Compute Optimizer ML and real pricing. Read-only and safe. | 10 | 5 | 1 |


### PR DESCRIPTION
Hey! 👋

I built AWS Cost Saver - a plugin that scans AWS accounts for wasted spend.

**What it does:**
- 173 automated checks across EC2, RDS, S3, Lambda, and more
- ML-powered recommendations from AWS Compute Optimizer
- Real pricing from AWS API (no guessing)
- Read-only and safe

**Real result:** Cut one account from $105/day → $42/day (60% savings)

**Install:**
```bash
/plugin marketplace add git@github.com:prajapatimehul/claude-aws-cost-saver.git
/plugin install aws-cost-saver
```

Repo: https://github.com/prajapatimehul/claude-aws-cost-saver

Thanks for maintaining this list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Claude Code plugin entry to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->