### PR TITLE
Add pm-skills - 24 product-management agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@
 | 98 | [osgrep](https://github.com/Ryandonofrio3/osgrep) | Open Source Semantic Search for your AI Agent | 1029 | 5 | 1 |
 | 99 | [skills](https://github.com/expo/skills) | A collection of AI agent skills for working with Expo projects and Expo Application Services | 1022 | 9 | 3 |
 | 100 | [terraform-skill](https://github.com/antonbabenko/terraform-skill) | The Claude Agent Skill for Terraform and OpenTofu - testing, modules, CI/CD, and production patterns | 1019 | 13 | 1 |
+| 101 | [pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 plug-and-play product-management agent skills spanning the Triple Diamond, from discovery interviews to experiment results, plus templates and workflow bundles. | 23 | 2 | 24 |


### PR DESCRIPTION
## What

Adds [pm-skills](https://github.com/product-on-purpose/pm-skills) as entry #101 in the README table.

## About pm-skills

- **24 plug-and-play product-management agent skills** spanning the full Triple Diamond (Discover, Define, Develop, Deliver, Measure, Iterate)
- Follows the [agentskills.io specification](https://agentskills.io/specification)
- Includes templates and workflow bundles for consistent, professional PM outputs
- Apache 2.0 licensed
- 23 stars, 2 subscribers, 24 skills

## Entry format

Matches the existing table format exactly:

```
| 101 | [pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 plug-and-play product-management agent skills spanning the Triple Diamond, from discovery interviews to experiment results, plus templates and workflow bundles. | 23 | 2 | 24 |
```

Thanks for maintaining this list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated README documentation table with a new pm-skills entry, including resource description and GitHub repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->