### PR TITLE
Add Helium MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,6 @@
 | 99 | [claude-scholar](https://github.com/Galaxy-Dawn/claude-scholar) | Semi-automated research assistant for academic research and software development. Supports Claude Code, OpenCode, and Codex CLI across ideation, coding, experiments, writing, and publication. | 3199 | 18 | 1 |
 | 100 | [arscontexta](https://github.com/agenticnotetaking/arscontexta) | Claude Code plugin that generates individualized knowledge systems from conversation. You describe how you think and work, have a conversation and get a complete second brain as markdown files you own. | 3122 | 28 | 1 |
 
-## Remote MCP servers
+## Remote MCP Servers
 
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for market intelligence, ML options pricing, and news bias analysis across 5,000+ sources. Free tier, no API key. [Documentation](https://heliumtrades.com/mcp).

--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@
 | 98 | [Acontext](https://github.com/memodb-io/Acontext) | Agent Skills as a Memory Layer | 3312 | 28 | 1 |
 | 99 | [claude-scholar](https://github.com/Galaxy-Dawn/claude-scholar) | Semi-automated research assistant for academic research and software development. Supports Claude Code, OpenCode, and Codex CLI across ideation, coding, experiments, writing, and publication. | 3199 | 18 | 1 |
 | 100 | [arscontexta](https://github.com/agenticnotetaking/arscontexta) | Claude Code plugin that generates individualized knowledge systems from conversation. You describe how you think and work, have a conversation and get a complete second brain as markdown files you own. | 3122 | 28 | 1 |
+
+## Remote MCP servers
+
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for market intelligence, ML options pricing, and news bias analysis across 5,000+ sources. Free tier, no API key. [Documentation](https://heliumtrades.com/mcp).


### PR DESCRIPTION
**Update:** Addressed maintainer feedback — no README changes needed.

[helium-mcp](https://github.com/connerlambden/helium-mcp) now includes `.claude-plugin/marketplace.json` and `plugin.json` on `main` for Claude Code plugin indexing:

- [marketplace.json](https://github.com/connerlambden/helium-mcp/blob/main/.claude-plugin/marketplace.json)
- [plugin.json](https://github.com/connerlambden/helium-mcp/blob/main/.claude-plugin/plugin.json)

Remote MCP: `https://heliumtrades.com/mcp` — news bias (37 dimensions, 216 sources), live market data, ML options pricing. Free tier, no API key for first 50 calls.

Docs: https://heliumtrades.com/mcp-page/