### PR TITLE
feat: add ARIA attributes to plugin components

### DIFF
--- a/ui/src/components/repo/PluginCard.tsx
+++ b/ui/src/components/repo/PluginCard.tsx
@@ -26,14 +26,16 @@ export function PluginCard({ plugin, repoPath, repo }: PluginCardProps) {
       <PluginHeader category={plugin.category} name={plugin.name} version={plugin.version} />
       {plugin.name ? <InstallCommand pluginId={plugin.id} pluginName={plugin.name} repoPath={repoPath} /> : null}
       <CardContent className="space-y-2 pt-1">
-        <PluginDescription description={plugin.description} />
-        <PluginSource defaultBranch={repo?.default_branch} repoPath={repoPath} source={plugin.source} />
-        <PluginAuthor author={plugin.author} />
-        <PluginId id={plugin.id} />
-        <PluginKeywords keywords={plugin.keywords} />
-        <PluginList defaultBranch={repo?.default_branch} items={plugin.commands} repoPath={repoPath} title="Commands" />
-        <PluginList defaultBranch={repo?.default_branch} items={plugin.agents} repoPath={repoPath} title="Agents" />
-        <PluginList defaultBranch={repo?.default_branch} items={plugin.mcpServers} repoPath={repoPath} title="MCP Servers" />
+        <article aria-label={`Plugin: ${plugin.name || 'Unnamed Plugin'}`}>
+          <PluginDescription description={plugin.description} />
+          <PluginSource defaultBranch={repo?.default_branch} repoPath={repoPath} source={plugin.source} />
+          <PluginAuthor author={plugin.author} />
+          <PluginId id={plugin.id} />
+          <PluginKeywords keywords={plugin.keywords} />
+          <PluginList defaultBranch={repo?.default_branch} items={plugin.commands} repoPath={repoPath} title="Commands" />
+          <PluginList defaultBranch={repo?.default_branch} items={plugin.agents} repoPath={repoPath} title="Agents" />
+          <PluginList defaultBranch={repo?.default_branch} items={plugin.mcpServers} repoPath={repoPath} title="MCP Servers" />
+        </article>
       </CardContent>
     </Card>
   )

--- a/ui/src/components/repo/PluginHeader.tsx
+++ b/ui/src/components/repo/PluginHeader.tsx
@@ -13,10 +13,8 @@ export function PluginHeader({ name, version, category }: PluginHeaderProps) {
       <div className="flex items-start justify-between">
         <div>
           <CardTitle className="font-bold text-lg transition-colors duration-300 group-hover:text-primary">
-            <h3>
-              {name || 'Unnamed Plugin'}
-              {version ? <span className="text-muted-foreground">@{version}</span> : null}
-            </h3>
+            <h3>{name || 'Unnamed Plugin'}</h3>
+            {version ? <span className="text-muted-foreground">@{version}</span> : null}
           </CardTitle>
         </div>
         {category ? (

--- a/ui/src/components/repo/PluginHeader.tsx
+++ b/ui/src/components/repo/PluginHeader.tsx
@@ -13,8 +13,10 @@ export function PluginHeader({ name, version, category }: PluginHeaderProps) {
       <div className="flex items-start justify-between">
         <div>
           <CardTitle className="font-bold text-lg transition-colors duration-300 group-hover:text-primary">
-            <h3>{name || 'Unnamed Plugin'}</h3>
-            {version ? <span className="text-muted-foreground">@{version}</span> : null}
+            <h3>
+              {name || 'Unnamed Plugin'}
+              {version ? <span className="text-muted-foreground">@{version}</span> : null}
+            </h3>
           </CardTitle>
         </div>
         {category ? (

--- a/ui/src/components/repo/PluginList.tsx
+++ b/ui/src/components/repo/PluginList.tsx
@@ -1,3 +1,7 @@
+'use client'
+
+import { useId } from 'react'
+
 interface PluginListProps {
   title: string
   items?: string[]
@@ -5,12 +9,24 @@ interface PluginListProps {
   defaultBranch?: string
 }
 
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'heading'
+  )
+}
+
 export function PluginList({ title, items, repoPath, defaultBranch }: PluginListProps) {
+  const generatedId = useId()
+  const headingId = `${generatedId}-${slugify(title)}-heading`
+
   if (!items?.length) return null
 
   return (
-    <section aria-labelledby={`${title}-heading`} className="plugin-list">
-      <h6 className="mb-0.5 font-medium text-sm" id={`${title}-heading`}>
+    <section aria-labelledby={headingId} className="plugin-list">
+      <h6 className="mb-0.5 font-medium text-sm" id={headingId}>
         {title} ({items.length})
       </h6>
       <ul className="list-inside list-disc space-y-0.5 text-muted-foreground text-sm">

--- a/ui/src/components/repo/PluginList.tsx
+++ b/ui/src/components/repo/PluginList.tsx
@@ -9,8 +9,8 @@ export function PluginList({ title, items, repoPath, defaultBranch }: PluginList
   if (!items?.length) return null
 
   return (
-    <div>
-      <h6 className="mb-0.5 font-medium text-sm">
+    <section aria-labelledby={`${title}-heading`} className="plugin-list">
+      <h6 className="mb-0.5 font-medium text-sm" id={`${title}-heading`}>
         {title} ({items.length})
       </h6>
       <ul className="list-inside list-disc space-y-0.5 text-muted-foreground text-sm">
@@ -31,6 +31,6 @@ export function PluginList({ title, items, repoPath, defaultBranch }: PluginList
           )
         })}
       </ul>
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- Add ARIA attributes to PluginCard and PluginList components for improved accessibility
- Use semantic HTML elements (`<section>` instead of `<div>`)

## Changes
- PluginCard.tsx: Wrap content in `<article>` with aria-label
- PluginList.tsx: Replace div with section, add aria-labelledby and heading id
- PluginHeader.tsx: Fix version span placement inside h3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved accessibility for plugin information by using more semantic HTML and adding appropriate ARIA labeling.
  * Updated plugin list layout semantics and connected headings to their containers for clearer screen reader navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->