### PR TITLE
feat: add canonical URLs to repo pages

### DIFF
--- a/ui/src/app/[...repo]/layout.tsx
+++ b/ui/src/app/[...repo]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { BASE_URL } from '../../lib/constants.ts'
 
 type Props = {
   params: Promise<{ repo: string[] }>
@@ -7,6 +8,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { repo } = await params
   const repoName = repo.join('/')
+  const canonicalUrl = `${BASE_URL}/${encodeURIComponent(repoName)}`
 
   return {
     title: `${repoName}`,
@@ -26,10 +28,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       `${repoName} plugins`,
       `${repoName} Claude Code`,
     ],
+    alternates: {
+      canonical: canonicalUrl,
+    },
     openGraph: {
       title: `${repoName}`,
       description: `Explore ${repoName} repository with Claude Code plugins, MCP servers, and agent skills. View plugin adoption metrics, AI development tools, and automated workflow integrations`,
       type: 'website',
+      url: canonicalUrl,
       images: [
         {
           url: '/android-chrome-512x512.png',

--- a/ui/src/app/[...repo]/layout.tsx
+++ b/ui/src/app/[...repo]/layout.tsx
@@ -8,7 +8,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { repo } = await params
   const repoName = repo.join('/')
-  const canonicalUrl = `${BASE_URL}/${encodeURIComponent(repoName)}`
+  const canonicalUrl = `${BASE_URL}/${repo.map(encodeURIComponent).join('/')}`
 
   return {
     title: `${repoName}`,


### PR DESCRIPTION
## Summary
- Add canonical URL to repository metadata for SEO
- Use BASE_URL constant for generating canonical links

## Changes
- Add canonicalUrl to `generateMetadata` in layout.tsx
- Add `alternates.canonical` and `openGraph.url` properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced page metadata to improve search engine optimization and social media sharing by setting consistent canonical URLs and Open Graph URLs based on the current repository path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->