### PR TITLE
feat: enhance OpenGraph metadata for repo pages

### DIFF
--- a/ui/src/app/[...repo]/layout.tsx
+++ b/ui/src/app/[...repo]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { BASE_URL } from '../../lib/constants.ts'
 
 type Props = {
   params: Promise<{ repo: string[] }>
@@ -7,6 +8,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { repo } = await params
   const repoName = repo.join('/')
+  const canonicalUrl = `${BASE_URL}/${encodeURIComponent(repoName)}`
 
   return {
     title: `${repoName}`,
@@ -26,10 +28,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       `${repoName} plugins`,
       `${repoName} Claude Code`,
     ],
+    alternates: {
+      canonical: canonicalUrl,
+    },
     openGraph: {
       title: `${repoName}`,
       description: `Explore ${repoName} repository with Claude Code plugins, MCP servers, and agent skills. View plugin adoption metrics, AI development tools, and automated workflow integrations`,
-      type: 'website',
+      type: 'article',
+      url: canonicalUrl,
+      siteName: 'Awesome Claude Plugins',
+      locale: 'en_US',
       images: [
         {
           url: '/android-chrome-512x512.png',
@@ -41,8 +49,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${repoName}`,
-      description: `Explore ${repoName} repository with Claude Code plugins, MCP servers, and agent skills. View plugin adoption metrics, AI development tools, and automated workflow integrations`,
+      title: `${repoName} | Awesome Claude Plugins`,
+      description: `Explore ${repoName} repository with Claude Code plugins, MCP servers, and agent skills. View plugin adoption metrics, AI development tools.`,
       images: ['/android-chrome-512x512.png'],
     },
   }

--- a/ui/src/app/[...repo]/layout.tsx
+++ b/ui/src/app/[...repo]/layout.tsx
@@ -8,7 +8,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { repo } = await params
   const repoName = repo.join('/')
-  const canonicalUrl = `${BASE_URL}/${encodeURIComponent(repoName)}`
+  const canonicalUrl = `${BASE_URL}/${repoName}`
 
   return {
     title: `${repoName}`,


### PR DESCRIPTION
## Summary
- Enhance OpenGraph and Twitter metadata for repository pages
- Add url, siteName, locale properties to OpenGraph
- Concatenate site name to title for better social sharing

## Changes
- Add canonicalUrl generation
- Update openGraph.type to article
- Add openGraph.url, siteName, locale
- Update twitter.title to include site name
- Add alternates.canonical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced search engine optimization: Added canonical URL support and enriched metadata (including Open Graph and Twitter details) with URL, site name, and locale for more accurate indexing.
  * Improved social media sharing: Refined social card metadata formatting and presentation to enhance how pages appear when shared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->