### PR TITLE
feat: add theme persistence with custom storage key

### DIFF
--- a/ui/src/components/common/ThemeToggle.tsx
+++ b/ui/src/components/common/ThemeToggle.tsx
@@ -6,6 +6,12 @@ import { useEffect, useState } from 'react'
 import { Button } from '../ui/button.tsx'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu.tsx'
 
+const THEME_LABELS = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+} as const
+
 export function ThemeToggle() {
   const { setTheme, resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
@@ -15,13 +21,24 @@ export function ThemeToggle() {
   }, [])
 
   const isDark = mounted ? resolvedTheme === 'dark' : false
+  const currentTheme = mounted ? resolvedTheme : 'system'
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button className="relative" size="icon" suppressHydrationWarning variant="outline">
-          <Sun className={`h-[1.2rem] w-[1.2rem] transition-all ${isDark ? 'rotate-90 scale-0' : 'rotate-0 scale-100'}`} />
+        <Button
+          aria-label={`Current theme: ${THEME_LABELS[currentTheme as keyof typeof THEME_LABELS] || 'System'}`}
+          className="relative"
+          size="icon"
+          suppressHydrationWarning
+          variant="outline"
+        >
+          <Sun
+            aria-hidden="true"
+            className={`h-[1.2rem] w-[1.2rem] transition-all ${isDark ? 'rotate-90 scale-0' : 'rotate-0 scale-100'}`}
+          />
           <Moon
+            aria-hidden="true"
             className={`absolute inset-0 m-auto h-[1.2rem] w-[1.2rem] transition-all ${isDark ? 'rotate-0 scale-100' : 'rotate-90 scale-0'}`}
           />
           <span className="sr-only">Toggle theme</span>

--- a/ui/src/components/common/ThemeToggle.tsx
+++ b/ui/src/components/common/ThemeToggle.tsx
@@ -12,8 +12,10 @@ const THEME_LABELS = {
   system: 'System',
 } as const
 
+type ThemeMode = keyof typeof THEME_LABELS
+
 export function ThemeToggle() {
-  const { setTheme, resolvedTheme } = useTheme()
+  const { setTheme, resolvedTheme, theme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -21,13 +23,13 @@ export function ThemeToggle() {
   }, [])
 
   const isDark = mounted ? resolvedTheme === 'dark' : false
-  const currentTheme = mounted ? resolvedTheme : 'system'
+  const currentTheme = (mounted && theme ? theme : 'system') as ThemeMode
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          aria-label={`Current theme: ${THEME_LABELS[currentTheme as keyof typeof THEME_LABELS] || 'System'}`}
+          aria-label={`Toggle theme. Current theme: ${THEME_LABELS[currentTheme]}`}
           className="relative"
           size="icon"
           suppressHydrationWarning
@@ -41,7 +43,6 @@ export function ThemeToggle() {
             aria-hidden="true"
             className={`absolute inset-0 m-auto h-[1.2rem] w-[1.2rem] transition-all ${isDark ? 'rotate-0 scale-100' : 'rotate-90 scale-0'}`}
           />
-          <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/ui/src/providers/providers.tsx
+++ b/ui/src/providers/providers.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from './theme-provider.tsx'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" disableTransitionOnChange enableSystem>
+    <ThemeProvider attribute="class" defaultTheme="system" disableTransitionOnChange enableSystem storageKey="theme-preference">
       {children}
     </ThemeProvider>
   )


### PR DESCRIPTION
## Summary
- Add theme preference persistence using custom storage key
- Add ARIA labels to theme toggle icons for accessibility

## Changes
- Add THEME_LABELS constant for consistent labels
- Add currentTheme state for aria-label
- Add aria-label to theme toggle button
- Add aria-hidden to Sun/Moon icons
- Update ThemeProvider to use storageKey=theme-preference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme toggle accessibility improved with dynamic labels displaying the current theme mode
  * Theme preference storage now configured with a dedicated key for better persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->