### PR TITLE
Add Context Kit — Personal Context Artifacts (4 templates + 5 Claude Code skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,5 @@
 | 98 | [connect](https://github.com/redpanda-data/connect) | Fancy stream processing made operationally mundane | 8695 | 112 | 1 |
 | 99 | [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) | Self-organizing AI second brain for Obsidian + Claude Code. Drop any source and Claude reads, links, and files it into one connected knowledge graph of plain Markdown you own. AI note-taking, personal knowledge management (PKM), and an open-source Notion alternative. Based on Karpathy's LLM Wiki pattern. | 8653 | 45 | 1 |
 | 100 | [claude-for-legal](https://github.com/anthropics/claude-for-legal) | A suite of plugins for legal workflows | 8604 | 99 | 13 |
+
+- **[Context Kit](https://github.com/JDDavenport/context-kit)** — Personal Context Artifacts: 4 Markdown templates + 5 Claude Code skills for giving AI agents deep personal context. MIT-licensed, one-command install.


### PR DESCRIPTION
## Add Context Kit — Personal Context Artifacts

**[Context Kit](https://github.com/JDDavenport/context-kit)** provides 4 Markdown templates + 5 Claude Code skills for giving AI agents deep, durable personal context.

- **What it solves:** Without persistent context, every AI session starts cold.
- **How it works:** Static `.context/` Markdown files + Claude Code skills that auto-load them.
- **Install:** `curl -fsSL https://raw.githubusercontent.com/JDDavenport/context-kit/main/install.sh | bash`
- **MIT-licensed**, 4 templates, 5 skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry for **Context Kit** in the “Top 100 Repositories” list, including a short description plus install and licensing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->